### PR TITLE
feat: 기존 Post 엔터티를 클래스,소모임,커뮤니티 총 3개의 Post 엔터티로 분류

### DIFF
--- a/src/main/java/com/FitToMe/project/Entity/ClassPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/ClassPost.java
@@ -31,7 +31,7 @@ public class ClassPost extends TimeBase {
     private Integer likeCnt;
     private Integer viewCnt;
     private Integer cost;
-    private Boolean isExecuting;
+    private Boolean isRecruiting;
 
     public ClassPost(User user, PostRegisterRequest postRegisterRequest) {
         this.user = user;

--- a/src/main/java/com/FitToMe/project/Entity/ClassPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/ClassPost.java
@@ -1,0 +1,42 @@
+package com.FitToMe.project.Entity;
+
+import com.FitToMe.project.Request.PostRegisterRequest;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClassPost extends TimeBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String imageURL;
+    private Integer totalParticipant;
+    private Integer participantNum;
+    private Integer likeCnt;
+    private Integer viewCnt;
+    private Integer cost;
+    private Boolean isExecuting;
+
+    public ClassPost(User user, PostRegisterRequest postRegisterRequest) {
+        this.user = user;
+        this.title = postRegisterRequest.getTitle();
+        this.content = postRegisterRequest.getContent();
+        this.imageURL = postRegisterRequest.getImageURL();
+    }
+}

--- a/src/main/java/com/FitToMe/project/Entity/ClassPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/ClassPost.java
@@ -28,7 +28,6 @@ public class ClassPost extends TimeBase {
     private String imageURL;
     private Integer totalParticipant;
     private Integer participantNum;
-    private Integer likeCnt;
     private Integer viewCnt;
     private Integer cost;
     private Boolean isRecruiting;

--- a/src/main/java/com/FitToMe/project/Entity/CommunityPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/CommunityPost.java
@@ -26,7 +26,6 @@ public class CommunityPost extends TimeBase {
     private String content;
 
     private String imageURL;
-    private Integer likeCnt;
     private Integer viewCnt;
 
     public CommunityPost(User user, PostRegisterRequest postRegisterRequest) {

--- a/src/main/java/com/FitToMe/project/Entity/CommunityPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/CommunityPost.java
@@ -1,0 +1,38 @@
+package com.FitToMe.project.Entity;
+
+import com.FitToMe.project.Request.PostRegisterRequest;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommunityPost extends TimeBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String imageURL;
+    private Integer likeCnt;
+    private Integer viewCnt;
+
+    public CommunityPost(User user, PostRegisterRequest postRegisterRequest) {
+        this.user = user;
+        this.title = postRegisterRequest.getTitle();
+        this.content = postRegisterRequest.getContent();
+        this.imageURL = postRegisterRequest.getImageURL();
+    }
+}

--- a/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
@@ -1,0 +1,42 @@
+package com.FitToMe.project.Entity;
+
+import com.FitToMe.project.Request.PostRegisterRequest;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SmallGroupPost extends TimeBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String imageURL;
+    private Integer totalParticipant;
+    private Integer participantNum;
+    private Integer likeCnt;
+    private Integer viewCnt;
+    private Integer cost;
+    private Boolean isExecuting;
+
+    public SmallGroupPost(User user, PostRegisterRequest postRegisterRequest) {
+        this.user = user;
+        this.title = postRegisterRequest.getTitle();
+        this.content = postRegisterRequest.getContent();
+        this.imageURL = postRegisterRequest.getImageURL();
+    }
+}

--- a/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
@@ -28,7 +28,6 @@ public class SmallGroupPost extends TimeBase {
     private String imageURL;
     private Integer totalParticipant;
     private Integer participantNum;
-    private Integer likeCnt;
     private Integer viewCnt;
     private Integer cost;
     private Boolean isRecruiting;

--- a/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
+++ b/src/main/java/com/FitToMe/project/Entity/SmallGroupPost.java
@@ -31,7 +31,7 @@ public class SmallGroupPost extends TimeBase {
     private Integer likeCnt;
     private Integer viewCnt;
     private Integer cost;
-    private Boolean isExecuting;
+    private Boolean isRecruiting;
 
     public SmallGroupPost(User user, PostRegisterRequest postRegisterRequest) {
         this.user = user;


### PR DESCRIPTION
## 👀 이슈

resolve #21

## 📌 개요

기존에 클래스, 소모임, 커뮤니티 Post 엔터티를 하나의 Post 엔터티로 통합시킴 
각각의 Post마다 필요한 정보가 달라 문제 발생 

## 👩‍💻 작업 사항

- 기존 Post 엔터티를 클래스, 소모임, 커뮤니티 총 3개의 Post 엔터티로 분류

## ✅ 참고 사항